### PR TITLE
fix for loading specs from file

### DIFF
--- a/src/workflow/prepareSpec/index.js
+++ b/src/workflow/prepareSpec/index.js
@@ -21,7 +21,7 @@ export default function prepareSpec(spec) {
     specRef = spec;
   } else if (isUrl(spec)) {
     specRef = spec;
-  } else if (typeof config === 'string') {
+  } else if (typeof spec === 'string') {
     if (process.browser) {
       throw new Error('Incorrect spec, only URL or object are supported in browser');
     } else {


### PR DESCRIPTION
Loading a spec from a file currently fails with `Incorrect spec`. This line seems wrong (`config` is undefined), and fixes that issue.

@zallek 